### PR TITLE
Cleanup branches that were mirrored in the past, but were now deleted in the remote

### DIFF
--- a/src/Khepin/Medusa/Command/UpdateReposCommand.php
+++ b/src/Khepin/Medusa/Command/UpdateReposCommand.php
@@ -42,7 +42,7 @@ EOT
         $dir = $config->repodir;
         $repos = glob($dir.'/*/*.git');
 
-        $fetchCmd = 'cd %s && git fetch';
+        $fetchCmd = 'cd %s && git fetch --prune';
         $updateCmd = 'cd %s && git update-server-info -f';
 
         foreach ($repos as $repo) {


### PR DESCRIPTION
Consider the situation:

* You mirror repository 1 with medusa
* Repository 1 has 3 branches: a, b and c
* Repository 1 delete branch c
* Medusa starts updating the Repository 1
* The local mirror has branches a, b and c and the remote only a and c

While adding `--prune` you will be in sync with the remote.

```
       -p, --prune
           Before fetching, remove any remote-tracking references that no longer exist on the remote. Tags are not subject to
           pruning if they are fetched only because of the default tag auto-following or due to a --tags option. However, if
           tags are fetched due to an explicit refspec (either on the command line or in the remote configuration, for example
           if the remote was cloned with the --mirror option), then they are also subject to pruning.
```