### PR TITLE
Use HTTPS for communication with Packagist

### DIFF
--- a/src/Khepin/Medusa/Command/AddRepoCommand.php
+++ b/src/Khepin/Medusa/Command/AddRepoCommand.php
@@ -25,7 +25,7 @@ class AddRepoCommand extends Command
     public function __construct()
     {
         parent::__construct();
-        $this->guzzle = new Client('http://packagist.org');
+        $this->guzzle = new Client('https://packagist.org');
     }
 
     protected function configure()

--- a/src/Khepin/Medusa/Command/MirrorCommand.php
+++ b/src/Khepin/Medusa/Command/MirrorCommand.php
@@ -43,7 +43,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('<info>First getting all dependencies</info>');
-        $this->guzzle = new Client('http://packagist.org');
+        $this->guzzle = new Client('https://packagist.org');
         $medusaConfig = $input->getArgument('config');
         $config = json_decode(file_get_contents($medusaConfig));
         $repos = array();

--- a/src/Khepin/Medusa/DependencyResolver.php
+++ b/src/Khepin/Medusa/DependencyResolver.php
@@ -25,7 +25,7 @@ class DependencyResolver
         $deps = array($this->package);
         $resolved = array();
 
-        $guzzle = new Client('http://packagist.org');
+        $guzzle = new Client('https://packagist.org');
 
         while (count($deps) > 0) {
             $package = $this->rename(array_pop($deps));


### PR DESCRIPTION
The communication with Packagist is done by HTTP so far.
Packagist is available via HTTPS.

Lets use the secure version here.