### PR TITLE
Catch exception on Packagist api request when dependency resolver failed

### DIFF
--- a/src/Khepin/Medusa/DependencyResolver.php
+++ b/src/Khepin/Medusa/DependencyResolver.php
@@ -34,7 +34,11 @@ class DependencyResolver
                 continue;
             }
 
-            $response = $guzzle->get('/packages/'.$package.'.json')->send()->getBody(true);
+            try {
+                $response = $guzzle->get('/packages/'.$package.'.json')->send()->getBody(true);
+            } catch (\Exception $e) {
+                continue;
+            }
             $package = json_decode($response);
 
             if (!is_null($package)) {


### PR DESCRIPTION
If the exception won't be catched, medusa just stops working

/cc @aaukt