### PR TITLE
Set higher timeouts for update command

### DIFF
--- a/src/Khepin/Medusa/Command/UpdateReposCommand.php
+++ b/src/Khepin/Medusa/Command/UpdateReposCommand.php
@@ -48,7 +48,7 @@ EOT
         foreach ($repos as $repo) {
             $output->writeln(' - Fetching latest changes in <info>'.$repo.'</info>');
             $process = new Process(sprintf($fetchCmd, $repo));
-            $process->run();
+            $process->setTimeout(300)->run();
 
             if (!$process->isSuccessful()) {
                 throw new \Exception($process->getErrorOutput());
@@ -57,7 +57,7 @@ EOT
             $output->writeln($process->getOutput());
 
             $process = new Process(sprintf($updateCmd, $repo));
-            $process->run();
+            $process->setTimeout(600)->run();
 
             if (!$process->isSuccessful()) {
                 throw new \Exception($process->getErrorOutput());

--- a/src/Khepin/Medusa/Command/UpdateReposCommand.php
+++ b/src/Khepin/Medusa/Command/UpdateReposCommand.php
@@ -48,7 +48,8 @@ EOT
         foreach ($repos as $repo) {
             $output->writeln(' - Fetching latest changes in <info>'.$repo.'</info>');
             $process = new Process(sprintf($fetchCmd, $repo));
-            $process->setTimeout(300)->run();
+            $process->setTimeout(300)
+                    ->run();
 
             if (!$process->isSuccessful()) {
                 throw new \Exception($process->getErrorOutput());
@@ -57,7 +58,8 @@ EOT
             $output->writeln($process->getOutput());
 
             $process = new Process(sprintf($updateCmd, $repo));
-            $process->setTimeout(600)->run();
+            $process->setTimeout(600)
+                    ->run();
 
             if (!$process->isSuccessful()) {
                 throw new \Exception($process->getErrorOutput());


### PR DESCRIPTION
Symfony process has a default timeout of 60sec. See https://github.com/symfony/Process/blob/master/Process.php#L148

In our production env of Medusa and for larger git repositories, this is not enough.
We encountered timeouts and needed to raise the timeouts.

I know that this is not the best solution to hardcode the timeout here.
A better solution would be to enable this as a part of the configuration or through an env var.

/cc @aaukt