### PR TITLE
Avoid HTTP Calls to Packagist for system packages like php, ext-xml or lib-icu

### DIFF
--- a/src/Khepin/Medusa/DependencyResolver.php
+++ b/src/Khepin/Medusa/DependencyResolver.php
@@ -28,9 +28,10 @@ class DependencyResolver
         $guzzle = new Client('https://packagist.org');
 
         while (count($deps) > 0) {
-            $package = $this->rename(array_pop($deps));
+            $package = array_pop($deps);
+            $package = $this->rename($package);
 
-            if (!$package) {
+            if (!$package || $this->isSystemPackage($package) === true) {
                 continue;
             }
 
@@ -60,6 +61,26 @@ class DependencyResolver
         }
 
         return $resolved;
+    }
+
+    private function isSystemPackage($package) {
+        // If the package name don't contain a "/" we will skip it here.
+        // In a composer.json in the require / require-dev part you normally add packages
+        // you depend on. A package name follows the format "vendor/package".
+        // E.g. symfony/console
+        // You can put other dependencies in here as well like `php` or `ext-zip`.
+        // Those dependencies will be skipped (because they don`t have a vendor ;)).
+        // The reason is simple: If you try to request the package "php" at packagist
+        // you won`t get a JSON response with information we expect.
+        // You will get valid HTML of the packagist search.
+        // To avoid those errors and to save API calls we skip dependencies without a vendor.
+        //
+        // This follows the documentation as well:
+        //
+        // 	The package name consists of a vendor name and the project's name.
+        // 	Often these will be identical - the vendor name just exists to prevent naming clashes.
+        //	Source: https://getcomposer.org/doc/01-basic-usage.md
+        return (strstr($package, '/')) ? false: true;
     }
 
     private function rename($package)


### PR DESCRIPTION
When mirroring packages like [symfony/intl](https://packagist.org/packages/symfony/intl) and you will fire a `bin/medusa mirror` command, medusa fires 8 HTTP calls for packages like `php`, `symfony/polyfill-intl-icu`, `symfony/polyfill-php54`, `ext-intl`, `lib-icu`, etc.

On Packagist side this leads to unnecessary requests like:

```
1.2.3.4 - - [11/Jun/2017:23:57:17 +0000] "GET /packages/php.json/ HTTP/1.1" 302 440 "-" "Guzzle/2.8.8 curl/7.49.1 PHP/7.0.9"
1.2.3.4 - - [11/Jun/2017:23:57:17 +0000] "GET /search?q=php.json&reason=vendor_not_found HTTP/1.1" 301 528 "-" "Guzzle/2.8.8 curl/7.49.1 PHP/7.0.9"
1.2.3.4 - - [11/Jun/2017:23:57:17 +0000] "GET /search/?q=php.json&reason=vendor_not_found HTTP/1.1" 200 2632 "-" "Guzzle/2.8.8 curl/7.49.1 PHP/7.0.9"
```

This PR skips all packages that don't contain a `/`. This means they don't have a vendor and are identified as a system package.